### PR TITLE
Fixed bug in FluxStore where creating a new store would only extend an already

### DIFF
--- a/angular-flux.js
+++ b/angular-flux.js
@@ -45,7 +45,7 @@
       },
 
       createStore: function(options) {
-        return angular.extend(FluxStore, options);
+        return angular.extend({}, FluxStore, options);
       }
     }
 


### PR DESCRIPTION
created store in place, this was only causing issues if wanting to use waitFor method or if you have methods or fields on both stores with the same name, now FluxUtil.createStore, actually creates a new storeObject
